### PR TITLE
egl_switch: Enable EGL_KHR_create_context and allow the creation of compatibility profiles.

### DIFF
--- a/src/egl/drivers/switch/egl_switch.c
+++ b/src/egl/drivers/switch/egl_switch.c
@@ -635,7 +635,7 @@ switch_create_context(_EGLDriver *drv, _EGLDisplay *dpy, _EGLConfig *conf,
     enum st_context_error error;
     context->stctx = display->stapi->create_context(display->stapi, display->stmgr, &attribs, &error, NULL);
     if (error != ST_CONTEXT_SUCCESS) {
-        _eglError(EGL_BAD_ATTRIBUTE, "switch_create_context");
+        _eglError(EGL_BAD_MATCH, "switch_create_context");
         goto cleanup;
     }
 


### PR DESCRIPTION
Also respect the requested version number when creating the context.

Tested with waffle-gl. It is now possible to request a compatibility profile.