### PR TITLE
Expose EGL_KHR_surfaceless_context

### DIFF
--- a/src/egl/drivers/switch/egl_switch.c
+++ b/src/egl/drivers/switch/egl_switch.c
@@ -675,7 +675,8 @@ switch_make_current(_EGLDriver* drv, _EGLDisplay* dpy, _EGLSurface *dsurf,
 {
     struct switch_egl_display* disp = switch_egl_display(dpy);
     struct switch_egl_context* cont = switch_egl_context(ctx);
-    struct switch_egl_surface* surf = switch_egl_surface(dsurf);
+    struct switch_egl_surface* draw_surf = switch_egl_surface(dsurf);
+    struct switch_egl_surface* read_surf = switch_egl_surface(rsurf);
     CALLED();
 
     _EGLContext *old_ctx;
@@ -684,7 +685,8 @@ switch_make_current(_EGLDriver* drv, _EGLDisplay* dpy, _EGLSurface *dsurf,
     if (!_eglBindContext(ctx, dsurf, rsurf, &old_ctx, &old_dsurf, &old_rsurf))
         return EGL_FALSE;
 
-    return disp->stapi->make_current(disp->stapi, cont->stctx, surf->stfbi, surf->stfbi);
+    return disp->stapi->make_current(disp->stapi, cont ? cont->stctx : NULL, 
+        draw_surf ? draw_surf->stfbi : NULL, read_surf ? read_surf->stfbi : NULL);
 }
 
 static EGLBoolean

--- a/src/egl/drivers/switch/egl_switch.c
+++ b/src/egl/drivers/switch/egl_switch.c
@@ -439,6 +439,7 @@ switch_initialize(_EGLDriver *drv, _EGLDisplay *dpy)
         dpy->ClientAPIs |= EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT | EGL_OPENGL_ES3_BIT_KHR;
 
     dpy->Extensions.KHR_create_context = EGL_TRUE;
+    dpy->Extensions.KHR_surfaceless_context = EGL_TRUE;
   
     stmgr = CALLOC_STRUCT(st_manager);
     if (!stmgr) {


### PR DESCRIPTION
This fixes an invalid memory access when passing NULL parameters to eglMakeCurrent (unbinding the context/buffers).

Also fixes a bug where calling eglMakeCurrent(ctx, A, B) with A != B would be treated as if eglMakeCurrent(ctx, A, A) were called.

This was tested with the `egl-surfaceless-context-viewport` piglit test.