### PR TITLE
egl_switch: Report OpenGL and OpenGL ES 1/2 support.

### DIFF
--- a/src/egl/drivers/switch/egl_switch.c
+++ b/src/egl/drivers/switch/egl_switch.c
@@ -432,8 +432,14 @@ switch_initialize(_EGLDriver *drv, _EGLDisplay *dpy)
     dpy->DriverData = display;
     dpy->Version = 14;
 
-    dpy->Extensions.KHR_create_context = EGL_TRUE;
+    dpy->ClientAPIs = 0;
+    if (_eglIsApiValid(EGL_OPENGL_API))
+        dpy->ClientAPIs |= EGL_OPENGL_BIT;
+    if (_eglIsApiValid(EGL_OPENGL_ES_API))
+        dpy->ClientAPIs |= EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT | EGL_OPENGL_ES3_BIT_KHR;
 
+    dpy->Extensions.KHR_create_context = EGL_TRUE;
+  
     stmgr = CALLOC_STRUCT(st_manager);
     if (!stmgr) {
         _eglError(EGL_BAD_ALLOC, "switch_initialize");


### PR DESCRIPTION
eglQueryString(EGL_CLIENT_APIS) will now return a non-empty string with the supported APIs.