### PR TITLE
egl_switch: enable resolutions >720p in docked mode

### DIFF
--- a/src/egl/drivers/switch/egl_switch.c
+++ b/src/egl/drivers/switch/egl_switch.c
@@ -429,6 +429,10 @@ switch_initialize(_EGLDriver *drv, _EGLDisplay *dpy)
 
     stmgr->get_param = switch_st_get_param;
 
+    // enable resolutions >720p in docked mode,
+    // see https://switchbrew.github.io/libnx/gfx_8h_source.html
+    gfxInitResolutionDefault(); 
+
     gfxInitDefault();
 
     if ( dpy->Options.ForceSoftware )


### PR DESCRIPTION
calling gfxInitDefault() by itself disables all resolution >720p. The added call enables docked resolution 1080p and others. 