### PR TITLE
Revert "Disable rarely used legacy feedback mode that needs a software rasterizer fallback (saves 168KB)"

### DIFF
--- a/src/mesa/state_tracker/st_context.c
+++ b/src/mesa/state_tracker/st_context.c
@@ -453,9 +453,7 @@ st_destroy_context_priv(struct st_context *st, bool destroy_pipe)
    uint i;
 
    st_destroy_atoms(st);
-#ifndef __SWITCH__
    st_destroy_draw(st);
-#endif
    st_destroy_clear(st);
    st_destroy_bitmap(st);
    st_destroy_drawpix(st);
@@ -907,18 +905,14 @@ st_init_driver_functions(struct pipe_screen *screen,
    st_init_bitmap_functions(functions);
    st_init_copy_image_functions(functions);
    st_init_drawpixels_functions(functions);
-#ifndef __SWITCH__
    st_init_rasterpos_functions(functions);
-#endif
 
    st_init_drawtex_functions(functions);
 
    st_init_eglimage_functions(functions);
 
    st_init_fbo_functions(functions);
-#ifndef __SWITCH__
    st_init_feedback_functions(functions);
-#endif
    st_init_memoryobject_functions(functions);
    st_init_msaa_functions(functions);
    st_init_perfmon_functions(functions);

--- a/src/mesa/state_tracker/st_draw.c
+++ b/src/mesa/state_tracker/st_draw.c
@@ -347,7 +347,6 @@ st_init_draw_functions(struct dd_function_table *functions)
    functions->DrawIndirect = st_indirect_draw_vbo;
 }
 
-#ifndef __SWITCH__
 
 void
 st_destroy_draw(struct st_context *st)
@@ -380,8 +379,6 @@ st_get_draw_context(struct st_context *st)
 
    return st->draw;
 }
-
-#endif
 
 /**
  * Draw a quad with given position, texcoords and color.

--- a/src/mesa/state_tracker/st_program.c
+++ b/src/mesa/state_tracker/st_program.c
@@ -225,10 +225,8 @@ delete_variant(struct st_context *st, struct st_variant *v, GLenum target)
    if (v->driver_shader) {
       if (target == GL_VERTEX_PROGRAM_ARB &&
           ((struct st_common_variant*)v)->key.is_draw_shader) {
-#ifndef __SWITCH__
          /* Draw shader. */
          draw_delete_vertex_shader(st->draw, v->driver_shader);
-#endif
       } else if (st->has_shareable_shaders || v->st == st) {
          /* The shader's context matches the calling context, or we
           * don't care.
@@ -806,11 +804,9 @@ st_create_vp_variant(struct st_context *st,
    if (ST_DEBUG & DEBUG_PRINT_IR)
       tgsi_dump(state.tokens, 0);
 
-#ifndef __SWITCH__
    if (key->is_draw_shader)
       vpv->base.driver_shader = draw_create_vertex_shader(st->draw, &state);
    else
-#endif
       vpv->base.driver_shader = pipe->create_vs_state(pipe, &state);
 
    if (state.tokens) {


### PR DESCRIPTION
This reverts commit a1adb814677c62e95a4d93edf7505c41fb444c06.

Currently, in ScummVM, there are some calls to glRasterPos2i which result in an instant crash.
**st_init_rasterpos_functions** needs to be reactivated to fix the problem.